### PR TITLE
Fix MTL4 test

### DIFF
--- a/test_external/mtl4/Jamfile.v2
+++ b/test_external/mtl4/Jamfile.v2
@@ -26,6 +26,5 @@ project
 test-suite "odeint-mtl4"
     :
     [ run mtl4_resize.cpp ]
-    [ run lorenz.cpp ]
     : <testing.launcher>valgrind
     ;


### PR DESCRIPTION
Commit 75b8f0a4a35425c3869b6cb793339300550c6025 added lorenz.cpp to the MTL4 test, but there is no such file in this directory, so the test was always failing.