### PR TITLE
Update Jamfile.v2

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -10,6 +10,7 @@ using quickbook ;
 using boostbook ;
 using doxygen ;
 import modules ;
+path-constant here : . ;
 
 project : requirements
         <include>$(BOOST_ROOT)/tools/auto_index/include
@@ -227,9 +228,9 @@ boostbook standalone
     <format>pdf:<xsl:param>admon.graphics.extension=".svg"  #
     <format>pdf:<xsl:param>use.role.for.mediaobject=1 # Use print role on next line.
     <format>pdf:<xsl:param>preferred.mediaobject.role=print # pdf role is to be printed.
-    <format>pdf:<xsl:param>img.src.path=$(images_location)/ # Path of image (.svg) files. (Note trailing /) ? 
-    <format>pdf:<xsl:param>admon.graphics.path=$(nav_images)/ # path to admonition (warning, note...) image (.svg) files.
-    <format>pdf:<xsl:param>draft.mode="yes" # Yes if draft watermark wanted!
+    <format>pdf:<xsl:param>img.src.path=$(here)/html/ # Path of image (.svg) files. (Note trailing /) ? 
+    #<format>pdf:<xsl:param>admon.graphics.path=$(nav_images)/ # path to admonition (warning, note...) image (.svg) files.
+    #<format>pdf:<xsl:param>draft.mode="yes" # Yes if draft watermark wanted!
     #<format>pdf:<xsl:param>draft.watermark.image="draft.png" # Watermark (local copy).
     #<format>pdf:<xsl:param>draft.watermark.image=http://docbook.sourceforge.net/release/images/draft.png # Watermark.
 
@@ -271,11 +272,6 @@ boostbook standalone
 # will rename the file to the expected filename, here quick_auto_dox_index.pdf.
 # <location>. means installed in same place as this jamfile, /doc.
 
-install pdf-install : standalone : <install-type>PDF <location>. <name>checks.pdf ;
+install pdfinstall : standalone : <install-type>PDF <location>. <name>odeint.pdf ;
 
 install callouts : [ glob src/images/callouts/*.png ] : <location>html/images/callouts ;
-
-
-
-
-


### PR DESCRIPTION
Fix PDF documentation build:
Fix path to images when building PDF.
Use default path for admon graphics.
Turn off draft mode - it's not a draft anymore.
Change name of pdf install rule - apparently Boost.Build no longer accepts target names with hyphens in them :-(
