### PR TITLE
Fix compilation warning

### DIFF
--- a/include/boost/numeric/odeint/util/unwrap_reference.hpp
+++ b/include/boost/numeric/odeint/util/unwrap_reference.hpp
@@ -31,7 +31,7 @@
 namespace boost {
 
 #if BOOST_NUMERIC_ODEINT_CXX11
-template<typename T> struct reference_wrapper;
+template<typename T> class reference_wrapper;
 
 template<typename T> struct unwrap_reference;
 #endif


### PR DESCRIPTION
warning: struct template 'reference_wrapper' was previously declared as a class template [-Wmismatched-tags]
include/boost/core/ref.hpp:59:25: note: previous use is here