### PR TITLE
Fix my_vector.cpp sample

### DIFF
--- a/examples/my_vector.cpp
+++ b/examples/my_vector.cpp
@@ -32,11 +32,19 @@ public:
 
 // ... [ implement container interface ]
 //]
+#ifdef DEBUG
+    const double & operator[]( const size_t n ) const
+    { return m_v.at(n); }
+
+    double & operator[]( const size_t n )
+    { return m_v.at(n); }
+#else
     const double & operator[]( const size_t n ) const
     { return m_v[n]; }
 
     double & operator[]( const size_t n )
     { return m_v[n]; }
+#endif
 
     iterator begin()
     { return m_v.begin(); }

--- a/examples/my_vector.cpp
+++ b/examples/my_vector.cpp
@@ -24,16 +24,10 @@ public:
     typedef vector::const_iterator const_iterator;
 
 public:
-    my_vector( const size_t N )
+    my_vector( const size_t N = MAX_N )
         : m_v( N )
     { 
-        m_v.reserve( MAX_N );
-    }
-
-    my_vector()
-        : m_v()
-    {
-        m_v.reserve( MAX_N );
+        assert( N <= MAX_N );
     }
 
 // ... [ implement container interface ]


### PR DESCRIPTION
The my_vector type in the sample is flawed.

Questionable reserve() calls in the code my have hidden the issue to date. See:

 * https://github.com/headmyshoulder/odeint-v2/issues/180
 * http://stackoverflow.com/a/33533309/85371

Attached PR is the proposed fix in 2 clean commits.