### PR TITLE
Remove .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "doc"]
-	path = doc
-	url = git@github.com:headmyshoulder/odeint-v2.git


### PR DESCRIPTION
Hi. Submodule 'doc' was removed at 431bced209cc570db6a3aaca60c5ebe965cca10f. So I think that .gitmodules file should be removed.
