### PR TITLE
Fixed dense_output_runge_kutta<Stepper, stepper_tag>::do_step(...)

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -1,0 +1,43 @@
+# Copyright 2009-2012 Karsten Ahnert
+# Copyright 2010-2013 Mario Mulansky
+# Copyright 2013 Pascal Germroth
+# Distributed under the Boost Software License, Version 1.0. (See
+# accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import os ;
+import modules ;
+import path ;
+
+path-constant BOOST_ROOT : [ os.environ BOOST_ROOT ] ; 
+
+project 
+   : requirements 
+     <include>include&&$(BOOST_ROOT)
+     <toolset>gcc:<cxxflags>"-Wall -Wno-unused-parameter -Wno-unused-variable -Wno-unknown-pragmas -Wno-unused-local-typedefs"
+     <toolset>clang:<cxxflags>"-Wall -Wextra -Wno-unknown-warning-option -Wno-unused-function -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-local-typedef"
+     <toolset>intel:<cxxflags>"-ipo"
+   ;
+
+# tests, regression tests and examples
+build-project test ;
+build-project test/numeric ;
+build-project examples ;
+# build-project performance ;
+# build-project openmp ;
+# build-project performance/mpi ;
+
+
+# additional tests with external libraries :
+# build-project test_external/eigen ;
+# build-project test_external/gmp ;
+# build-project test_external/gsl ;
+# build-project test_external/mkl ;
+# build-project test_external/mtl4 ;
+# build-project test_external/thrust ;
+# build-project test_external/vexcl ;
+# build-project test_external/mpi ;
+
+
+# documentation:
+# build-project doc ;

--- a/include/boost/numeric/odeint/stepper/dense_output_runge_kutta.hpp
+++ b/include/boost/numeric/odeint/stepper/dense_output_runge_kutta.hpp
@@ -126,7 +126,7 @@ public:
         m_t_old = m_t;
         m_t += m_dt;
         toggle_current_state();
-        return std::make_pair( m_t_old , m_dt );
+        return std::make_pair( m_t_old , m_t );
     }
 
     /*


### PR DESCRIPTION
do_step must return the pair (t, t+dt) but (t, dt) is returned.

Note that dense_output_runge_kutta<Stepper, explicit_controlled_stepper_fsal_tag>::do_step(...)
works correctly.