### PR TITLE
Generalize is resizable

### DIFF
--- a/include/boost/numeric/odeint/algebra/vector_space_algebra.hpp
+++ b/include/boost/numeric/odeint/algebra/vector_space_algebra.hpp
@@ -30,7 +30,7 @@ namespace odeint {
 /*
  * This class template has to be overload in order to call vector_space_algebra::norm_inf
  */
-template< class State > struct vector_space_norm_inf;
+template< class State, class Enabler = void > struct vector_space_norm_inf;
 
 /*
  * Example: instantiation for sole doubles and complex

--- a/include/boost/numeric/odeint/util/is_resizeable.hpp
+++ b/include/boost/numeric/odeint/util/is_resizeable.hpp
@@ -45,14 +45,14 @@ struct is_resizeable_sfinae : boost::false_type {};
 template< typename Container >
 struct is_resizeable : is_resizeable_sfinae< Container > {};
 
+template <class>
+using voider = void;
 
+template <class Container>
+using try_resize = decltype(std::declval<Container>().resize(1u));
 
-/*
- * specialization for std::vector
- */
-template< class V, class A >
-struct is_resizeable< std::vector< V , A  > > : boost::true_type {};
-
+template <class Container>
+struct is_resizeable_sfinae<Container, voider<try_resize<Container>>> : boost::true_type {};
 
 /*
  * sfinae specialization for fusion sequences


### PR DESCRIPTION
I am sure I should have found the 'voider' or 'void_t' somewherein boost, but I failed:( Sry, please point me to the correct place. 
Else I hope you like this pull request. I came across the point when trying to use odeint with dynamic Eigen vectors. While I could just specialize the is_resizeable I consider it preferable to auto-detect the resize function and only opt-out if your resize-function does not resize:)
Please let me know if you follow my reasoning or have another perspective.