### PR TITLE
Fixed recursion in extract_value_type

### DIFF
--- a/include/boost/numeric/odeint/algebra/detail/extract_value_type.hpp
+++ b/include/boost/numeric/odeint/algebra/detail/extract_value_type.hpp
@@ -18,7 +18,10 @@
 #define BOOST_NUMERIC_ODEINT_ALGEBRA_DETAIL_EXTRACT_VALUE_TYPE_HPP_INCLUDED
 
 #include <boost/utility.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/mpl/has_xxx.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 BOOST_MPL_HAS_XXX_TRAIT_DEF(value_type)
 
@@ -28,24 +31,20 @@ namespace odeint {
 namespace detail {
 
 template< typename S , typename Enabler = void >
-struct extract_value_type {};
+struct extract_value_type
+{
+    typedef S type;
+};
 
 // as long as value_types are defined we go down the value_type chain
 // e.g. returning S::value_type::value_type::value_type
 
 template< typename S >
-struct extract_value_type<S , typename boost::disable_if< has_value_type<S> >::type >
-{
-    // no value_type defined, return S
-    typedef S type;
-};
-
-template< typename S >
 struct extract_value_type< S , typename boost::enable_if< has_value_type<S> >::type >
-{
-    // go down the value_type
-    typedef typename extract_value_type< typename S::value_type >::type type;
-};
+  : mpl::if_< is_same< S, typename S::value_type > ,
+        mpl::identity< S > , // cut the recursion if S and S::value_type are the same
+        extract_value_type< typename S::value_type > >::type
+{};
 
 } } } }
 


### PR DESCRIPTION
Some types (like Boost.Multiprecision ones) define `value_type` to the same type as they are, what causes `extract_value_type` instantiation to fail with an incomplete type instantiation error.

Fixes tests:
* `runge_kutta_concepts`
* `runge_kutta_controlled_concepts`
* `runge_kutta_error_concepts`