### PR TITLE
 Make OpenMP range algebra buildable with MSVC

### DIFF
--- a/include/boost/numeric/odeint/external/openmp/openmp_range_algebra.hpp
+++ b/include/boost/numeric/odeint/external/openmp/openmp_range_algebra.hpp
@@ -41,10 +41,11 @@ struct openmp_range_algebra
     BOOST_ASSERT_MSG( len == boost::size(s ## n), "All state ranges must have the same size." ); \
     typename boost::range_iterator<S ## n>::type beg ## n = boost::begin(s ## n);
 #define BOOST_ODEINT_GEN_BODY(n) \
-    const size_t len = boost::size(s0); \
+    typedef typename boost::range_size<S0>::type index_type; \
+    const index_type len = boost::size(s0); \
     BOOST_PP_REPEAT(n, BOOST_ODEINT_GEN_LOCAL, ~) \
     _Pragma("omp parallel for schedule(runtime)") \
-    for( size_t i = 0 ; i < len ; i++ ) \
+    for( index_type i = 0 ; i < len ; i++ ) \
         op( BOOST_PP_ENUM_BINARY_PARAMS(n, beg, [i] BOOST_PP_INTERCEPT) );
 BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
 #undef BOOST_ODEINT_GEN_BODY
@@ -53,47 +54,53 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
 #else
 
     template< class S0 , class Op > static void for_each1 ( S0 &s0 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] );
     }
     template< class S0 , class S1 , class Op > static void for_each2 ( S0 &s0 , S1 &s1 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] );
     }
     template< class S0 , class S1 , class S2 , class Op > static void for_each3 ( S0 &s0 , S1 &s1 , S2 &s2 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class Op > static void for_each4 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
         typename boost::range_iterator<S3>::type beg3 = boost::begin(s3);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class Op > static void for_each5 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
         typename boost::range_iterator<S3>::type beg3 = boost::begin(s3);
         typename boost::range_iterator<S4>::type beg4 = boost::begin(s4);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class Op > static void for_each6 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -101,10 +108,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S4>::type beg4 = boost::begin(s4);
         typename boost::range_iterator<S5>::type beg5 = boost::begin(s5);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class Op > static void for_each7 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -113,10 +121,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S5>::type beg5 = boost::begin(s5);
         typename boost::range_iterator<S6>::type beg6 = boost::begin(s6);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class Op > static void for_each8 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -126,10 +135,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S6>::type beg6 = boost::begin(s6);
         typename boost::range_iterator<S7>::type beg7 = boost::begin(s7);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class S8 , class Op > static void for_each9 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , S8 &s8 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -140,10 +150,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S7>::type beg7 = boost::begin(s7);
         typename boost::range_iterator<S8>::type beg8 = boost::begin(s8);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class S8 , class S9 , class Op > static void for_each10 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , S8 &s8 , S9 &s9 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -155,10 +166,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S8>::type beg8 = boost::begin(s8);
         typename boost::range_iterator<S9>::type beg9 = boost::begin(s9);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class S8 , class S9 , class S10 , class Op > static void for_each11 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , S8 &s8 , S9 &s9 , S10 &s10 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -171,10 +183,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S9>::type beg9 = boost::begin(s9);
         typename boost::range_iterator<S10>::type beg10 = boost::begin(s10);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class S8 , class S9 , class S10 , class S11 , class Op > static void for_each12 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , S8 &s8 , S9 &s9 , S10 &s10 , S11 &s11 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -188,10 +201,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S10>::type beg10 = boost::begin(s10);
         typename boost::range_iterator<S11>::type beg11 = boost::begin(s11);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class S8 , class S9 , class S10 , class S11 , class S12 , class Op > static void for_each13 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , S8 &s8 , S9 &s9 , S10 &s10 , S11 &s11 , S12 &s12 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -206,10 +220,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S11>::type beg11 = boost::begin(s11);
         typename boost::range_iterator<S12>::type beg12 = boost::begin(s12);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] , beg12 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] , beg12 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class S8 , class S9 , class S10 , class S11 , class S12 , class S13 , class Op > static void for_each14 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , S8 &s8 , S9 &s9 , S10 &s10 , S11 &s11 , S12 &s12 , S13 &s13 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -225,10 +240,11 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S12>::type beg12 = boost::begin(s12);
         typename boost::range_iterator<S13>::type beg13 = boost::begin(s13);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] , beg12 [i] , beg13 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] , beg12 [i] , beg13 [i] );
     }
     template< class S0 , class S1 , class S2 , class S3 , class S4 , class S5 , class S6 , class S7 , class S8 , class S9 , class S10 , class S11 , class S12 , class S13 , class S14 , class Op > static void for_each15 ( S0 &s0 , S1 &s1 , S2 &s2 , S3 &s3 , S4 &s4 , S5 &s5 , S6 &s6 , S7 &s7 , S8 &s8 , S9 &s9 , S10 &s10 , S11 &s11 , S12 &s12 , S13 &s13 , S14 &s14 , Op op ) {
-        const size_t len = boost::size(s0);
+        typedef typename boost::range_size<S0>::type index_type;
+        const index_type len = boost::size(s0);
         typename boost::range_iterator<S0>::type beg0 = boost::begin(s0);
         typename boost::range_iterator<S1>::type beg1 = boost::begin(s1);
         typename boost::range_iterator<S2>::type beg2 = boost::begin(s2);
@@ -245,7 +261,7 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         typename boost::range_iterator<S13>::type beg13 = boost::begin(s13);
         typename boost::range_iterator<S14>::type beg14 = boost::begin(s14);
         #pragma omp parallel for schedule(runtime)
-        for( size_t i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] , beg12 [i] , beg13 [i] , beg14 [i] );
+        for( index_type i = 0 ; i < len ; i++ ) op( beg0 [i] , beg1 [i] , beg2 [i] , beg3 [i] , beg4 [i] , beg5 [i] , beg6 [i] , beg7 [i] , beg8 [i] , beg9 [i] , beg10 [i] , beg11 [i] , beg12 [i] , beg13 [i] , beg14 [i] );
     }
 
 #endif
@@ -257,12 +273,22 @@ BOOST_ODEINT_GEN_FOR_EACH(BOOST_ODEINT_GEN_BODY)
         using std::max;
         using std::abs;
         typedef typename norm_result_type< S >::type result_type;
+        typedef typename boost::range_size< S >::type index_type;
         result_type init = static_cast< result_type >( 0 );
-        const size_t len = boost::size(s);
+        const index_type len = boost::size(s);
         typename boost::range_iterator<const S>::type beg = boost::begin(s);
-#       pragma omp parallel for reduction(max: init) schedule(dynamic)
-        for( size_t i = 0 ; i < len ; ++i )
-            init = max( init , abs( beg[i] ) );
+
+        #pragma omp parallel
+        {
+            result_type local = init;
+            #pragma omp for schedule(runtime)
+            for( index_type i = 0 ; i < len ; ++i )
+                local = max(local, abs( beg[i] ));
+
+            #pragma omp critical
+            init = max(init, local);
+        }
+
         return init;
     }
 


### PR DESCRIPTION
Current implementation of openmp_range_algebra uses unsigned type (size_t) as index in for loops that are parallelized by OpenMP. This is not supported by MSVC. Additionally, as MSVC is still stuck with OpenMP 2.0 support, the OpenMP reduction syntax used by norm_inf also does not compile. The following patch fixes the issue; at least for MSVC 14.