### PR TITLE
refactor: use core/enable_if.hpp over utility.hpp

### DIFF
--- a/include/boost/numeric/odeint/algebra/detail/extract_value_type.hpp
+++ b/include/boost/numeric/odeint/algebra/detail/extract_value_type.hpp
@@ -17,7 +17,7 @@
 #ifndef BOOST_NUMERIC_ODEINT_ALGEBRA_DETAIL_EXTRACT_VALUE_TYPE_HPP_INCLUDED
 #define BOOST_NUMERIC_ODEINT_ALGEBRA_DETAIL_EXTRACT_VALUE_TYPE_HPP_INCLUDED
 
-#include <boost/utility.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/mpl/has_xxx.hpp>
 
 BOOST_MPL_HAS_XXX_TRAIT_DEF(value_type)


### PR DESCRIPTION
The later is deprecated. From utility.hpp:
> // Use of this header is discouraged and it will be deprecated.
> // Please include one or more of the headers below instead.