### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,37 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/odeint
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/compute//boost_compute
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/fusion//boost_fusion
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/math//boost_math
+        <source>/boost/mpi//boost_mpi
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/multi_array//boost_multi_array
+        <source>/boost/ublas//boost_ublas
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/range//boost_range
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/units//boost_units
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_odeint ]
+    [ alias all : boost_odeint examples performance test ]
+    ;
+
+call-if : boost-library odeint
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/odeint
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -12,7 +12,7 @@ constant boost_dependencies :
     /boost/core//boost_core
     /boost/fusion//boost_fusion
     /boost/iterator//boost_iterator
-    /boost/math//boost_math
+    /boost/math//boost_math_tr1
     /boost/mpi//boost_mpi
     /boost/mpl//boost_mpl
     /boost/multi_array//boost_multi_array

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/odeint

--- a/build.jam
+++ b/build.jam
@@ -5,33 +5,36 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/compute//boost_compute
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/fusion//boost_fusion
+    /boost/iterator//boost_iterator
+    /boost/math//boost_math
+    /boost/mpi//boost_mpi
+    /boost/mpl//boost_mpl
+    /boost/multi_array//boost_multi_array
+    /boost/ublas//boost_ublas
+    /boost/preprocessor//boost_preprocessor
+    /boost/range//boost_range
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits
+    /boost/units//boost_units
+    /boost/utility//boost_utility ;
+
 project /boost/odeint
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/compute//boost_compute
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/fusion//boost_fusion
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/math//boost_math
-        <library>/boost/mpi//boost_mpi
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/multi_array//boost_multi_array
-        <library>/boost/ublas//boost_ublas
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/range//boost_range
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/units//boost_units
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_odeint ]
+    [ alias boost_odeint : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_odeint examples performance test ]
     ;
 
 call-if : boost-library odeint
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,24 +7,24 @@ import project ;
 
 project /boost/odeint
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/compute//boost_compute
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/fusion//boost_fusion
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/math//boost_math
-        <source>/boost/mpi//boost_mpi
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/multi_array//boost_multi_array
-        <source>/boost/ublas//boost_ublas
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/range//boost_range
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/units//boost_units
-        <source>/boost/utility//boost_utility
+        <library>/boost/assert//boost_assert
+        <library>/boost/compute//boost_compute
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/fusion//boost_fusion
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/math//boost_math
+        <library>/boost/mpi//boost_mpi
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/multi_array//boost_multi_array
+        <library>/boost/ublas//boost_ublas
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/range//boost_range
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/units//boost_units
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/examples/2d_lattice/Jamfile.v2
+++ b/examples/2d_lattice/Jamfile.v2
@@ -6,7 +6,6 @@
 
 project
     : requirements 
-      <include>../../../../..
       <define>BOOST_ALL_NO_LIB=1
     ;
     

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -5,14 +5,16 @@
 # accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+using python ;
 
 project
-    : requirements 
+    : requirements
+      <library>/boost/odeint//boost_odeint
       <define>BOOST_ALL_NO_LIB=1
       <library>/python//python
-    : 
+    :
     ;
-    
+
 
 exe harmonic_oscillator : harmonic_oscillator.cpp ;
 exe solar_system : solar_system.cpp ;

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -9,6 +9,7 @@
 project
     : requirements 
       <define>BOOST_ALL_NO_LIB=1
+      <library>/python//python
     : 
     ;
     
@@ -36,12 +37,12 @@ exe stochastic_euler : stochastic_euler.cpp ;
 exe generation_functions : generation_functions.cpp ;
 exe heun : heun.cpp ;
 exe bind_member_functions : bind_member_functions.cpp ;
-exe bind_member_functions_cpp11 : bind_member_functions_cpp11.cpp : <cxxflags>-std=c++0x ;
-exe molecular_dynamics : molecular_dynamics.cpp : <cxxflags>-std=c++0x ;
-exe molecular_dynamics_cells : molecular_dynamics_cells.cpp : <cxxflags>-std=c++0x ;
+exe bind_member_functions_cpp11 : bind_member_functions_cpp11.cpp : <cxxstd>14 ;
+exe molecular_dynamics : molecular_dynamics.cpp : <cxxstd>14 ;
+exe molecular_dynamics_cells : molecular_dynamics_cells.cpp : <cxxstd>14 ;
 exe abm_precision : abm_precision.cpp ;
 exe integrate_times : integrate_times.cpp ;
-exe find_crossing : find_crossing.cpp : <cxxflags>-std=c++0x ;
+exe find_crossing : find_crossing.cpp : <cxxstd>14 ;
 
 build-project multiprecision ;
 # build-project mtl ;

--- a/examples/mpi/Jamfile.v2
+++ b/examples/mpi/Jamfile.v2
@@ -8,8 +8,8 @@
 project
     : requirements
       <define>BOOST_ALL_NO_LIB=1
-      <library>/boost//mpi
-      <library>/boost//timer
+      <library>/boost/mpi//boost_mpi
+      <library>/boost/timer//boost_timer
     ;
 
 exe phase_chain : phase_chain.cpp ;

--- a/examples/multiprecision/Jamfile
+++ b/examples/multiprecision/Jamfile
@@ -6,12 +6,12 @@
 
 
 project
-    : requirements 
+    : requirements
       <define>BOOST_ALL_NO_LIB=1
-      <source>/boost/multiprecision//boost_multiprecision
-    : 
+      <library>/boost/multiprecision//boost_multiprecision
+    :
     ;
-    
+
 
 exe lorenz_mp : lorenz_mp.cpp ;
 exe cmp_precision : cmp_precision.cpp ;

--- a/examples/multiprecision/Jamfile
+++ b/examples/multiprecision/Jamfile
@@ -8,6 +8,7 @@
 project
     : requirements 
       <define>BOOST_ALL_NO_LIB=1
+      <source>/boost/multiprecision//boost_multiprecision
     : 
     ;
     

--- a/examples/nt2/Jamfile.v2
+++ b/examples/nt2/Jamfile.v2
@@ -7,8 +7,6 @@
 #                     http://www.boost.org/LICENSE_1_0.txt
 #==============================================================================
 
-use-project boost : $(BOOST_ROOT) ;
-
 import os ;
 
 # This must be built using an NT2 installation.

--- a/examples/openmp/Jamfile.v2
+++ b/examples/openmp/Jamfile.v2
@@ -5,14 +5,13 @@
 # accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-use-project /boost : $(BOOST_ROOT) ;
 import openmp : * ;
 
 project
     : requirements
       <include>..
       <define>BOOST_ALL_NO_LIB=1
-      <library>/boost//timer
+      <library>/boost/timer//boost_timer
       [ openmp ]
     ;
 

--- a/examples/quadmath/Jamfile.v2
+++ b/examples/quadmath/Jamfile.v2
@@ -13,4 +13,4 @@ project
     
 lib quadmath : : <name>quadmath <link>shared ;
 
-exe black_hole : black_hole.cpp quadmath : <cxxflags>-std=c++0x ;
+exe black_hole : black_hole.cpp quadmath : <cxxstd>14 ;

--- a/examples/vexcl/Jamfile.v2
+++ b/examples/vexcl/Jamfile.v2
@@ -9,9 +9,6 @@
 import boost ;
 import os ;
 
-boost.use-project ;
-
-
 # change these lines to fit you configuration
 local HOME = [ os.environ HOME ] ;
 local VEXCL_INCLUDE = [ os.environ VEXCL_ROOT ] ;
@@ -22,11 +19,10 @@ OPENCL_INCLUDE = /usr/local/cuda/include ;
 lib opencl : : <name>OpenCL ;
 
 project : requirements
-        <implicit-dependency>/boost//headers
         <include>$(VEXCL_INCLUDE)
         <include>$(OPENCL_INCLUDE)
         <toolset>gcc:<cxxflags>-std=c++0x
-        <library>/boost//system/
+        <library>/boost/system//boost_system
         ;
 
 exe lorenz_ensemble : lorenz_ensemble.cpp opencl ;

--- a/performance/Jamfile.v2
+++ b/performance/Jamfile.v2
@@ -10,8 +10,7 @@ import path ;
 project
     : requirements
       <define>BOOST_ALL_NO_LIB=1
-      <include>../../../..
-      <cxxflags>-std=c++11
+      <cxxstd>11
       <toolset>gcc:<cxxflags>-ffast-math
       <toolset>intel:<cxxflags>"-fast -inline-forceinline"
     : default-build release
@@ -29,4 +28,5 @@ lib libpthread : : <name>pthread ;
 
 exe odeint_rk4_array
     : odeint_rk4_array.cpp
+      /boost/timer//boost_timer
     ;

--- a/performance/Jamfile.v2
+++ b/performance/Jamfile.v2
@@ -5,18 +5,19 @@
 
 import os ;
 import modules ;
-import path ; 
+import path ;
 
 project
     : requirements
+      <library>/boost/odeint//boost_odeint
       <define>BOOST_ALL_NO_LIB=1
       <cxxstd>11
       <toolset>gcc:<cxxflags>-ffast-math
       <toolset>intel:<cxxflags>"-fast -inline-forceinline"
     : default-build release
     ;
-    
-    
+
+
 lib libgsl : : <name>gsl ;
 lib libgslcblas : : <name>gslcblas ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -7,13 +7,13 @@
 
 # bring in rules for testing
 
-require-b2 5.0.1 ;
-import-search /boost/config/checks ;
 import testing ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 project
     : requirements
+      <library>/boost/odeint//boost_odeint
       <define>BOOST_ALL_NO_LIB=1
       # use test library
       <library>/boost/test//boost_unit_test_framework
@@ -81,10 +81,10 @@ test-suite "odeint"
     [ compile unwrap_boost_reference.cpp ]
     [ compile unwrap_reference.cpp ]
     [ compile std_array.cpp ]
-    : 
+    :
         <testing.launcher>valgrind
     ;
-    
+
 # also run numeric tests
 build-project numeric ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -7,23 +7,16 @@
 
 # bring in rules for testing
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
 import testing ;
-import ../../config/checks/config : requires ;
-
-# make sure you are using a new version of boost.build, otherwise the local
-# odeint will not be included properly
-# you can fix older boost.build versions by applying the patch provided in
-# odeint's root, e.g.:
-# cd ~/odeint-v2
-# sudo patch /usr/share/boost-build/build/toolset.jam toolset.jam.patch
-
-use-project boost : $(BOOST_ROOT) ;
+import config : requires ;
 
 project
     : requirements
       <define>BOOST_ALL_NO_LIB=1
       # use test library
-      <library>/boost//unit_test_framework
+      <library>/boost/test//boost_unit_test_framework
       <link>static
       <toolset>clang:<cxxflags>-Wno-unused-variable
       # <cxxflags>-D_SCL_SECURE_NO_WARNINGS
@@ -33,9 +26,9 @@ test-suite "odeint"
     :
     [ run euler_stepper.cpp ]
     # The following 3 tests use Boost.Multiprecision which requires C++14
-    [ run runge_kutta_concepts.cpp : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
-    [ run runge_kutta_error_concepts.cpp : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
-    [ run runge_kutta_controlled_concepts.cpp : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
+    [ run runge_kutta_concepts.cpp /boost/multiprecision//boost_multiprecision : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
+    [ run runge_kutta_error_concepts.cpp /boost/multiprecision//boost_multiprecision : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
+    [ run runge_kutta_controlled_concepts.cpp /boost/multiprecision//boost_multiprecision : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj <debug-symbols>off <toolset>msvc:<cxxflags>/bigobj [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
     [ run resizing.cpp ]
     [ run default_operations.cpp ]
     [ run range_algebra.cpp ]
@@ -46,7 +39,7 @@ test-suite "odeint"
     [ run stepper_copying.cpp ]
     [ run stepper_with_ranges.cpp ]
     [ run rosenbrock4.cpp ]
-    [ run rosenbrock4_mp.cpp ]
+    [ run rosenbrock4_mp.cpp /boost/multiprecision//boost_multiprecision ]
     [ run is_pair.cpp ]
     [ run adams_bashforth.cpp ]
     [ run adams_moulton.cpp ]

--- a/test/numeric/Jamfile.v2
+++ b/test/numeric/Jamfile.v2
@@ -11,6 +11,7 @@ import testing ;
 project
     : requirements
       <library>/boost/test//boost_unit_test_framework
+      <library>/boost/format//boost_format
       <define>BOOST_ALL_NO_LIB=1
       <link>static
       <toolset>clang:<cxxflags>-Wno-unused-variable

--- a/test/numeric/Jamfile.v2
+++ b/test/numeric/Jamfile.v2
@@ -8,13 +8,10 @@
 
 import testing ;
 
-use-project boost : $(BOOST_ROOT) ;
-
 project
     : requirements
       <library>/boost/test//boost_unit_test_framework
       <define>BOOST_ALL_NO_LIB=1
-      <include>../../include
       <link>static
       <toolset>clang:<cxxflags>-Wno-unused-variable
 

--- a/test/regression/Jamfile.v2
+++ b/test/regression/Jamfile.v2
@@ -5,17 +5,15 @@
 
 # bring in rules for testing
 
-
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
 import testing ;
-import ../../config/checks/config : requires ;
-
-use-project boost : $(BOOST_ROOT) ;
+import config : requires ;
 
 project
     : requirements
       <library>/boost/test//boost_unit_test_framework
       <define>BOOST_ALL_NO_LIB=1
-      <include>../../include
       <link>static
       <toolset>clang:<cxxflags>-Wno-unused-variable
 

--- a/test_external/eigen/Jamfile.v2
+++ b/test_external/eigen/Jamfile.v2
@@ -9,8 +9,6 @@
 import testing ;
 import os ;
 
-use-project boost : $(BOOST_ROOT) ;
-
 local EIGEN_ROOT = [ os.environ EIGEN_ROOT ] ;
 
 project

--- a/test_external/gmp/Jamfile.v2
+++ b/test_external/gmp/Jamfile.v2
@@ -6,7 +6,6 @@
 # bring in rules for testing
 
 import testing ;
-use-project boost : $(BOOST_ROOT) ;
 
 project gmp
     : requirements

--- a/test_external/gsl/Jamfile.v2
+++ b/test_external/gsl/Jamfile.v2
@@ -6,7 +6,6 @@
 # bring in rules for testing
 
 import testing ;
-use-project boost : $(BOOST_ROOT) ;
 
 project
     : requirements

--- a/test_external/mkl/Jamfile.v2
+++ b/test_external/mkl/Jamfile.v2
@@ -6,7 +6,6 @@
 # bring in rules for testing
 
 import testing ;
-use-project boost : $(BOOST_ROOT) ;
 
 project
     : requirements

--- a/test_external/mpi/Jamfile.v2
+++ b/test_external/mpi/Jamfile.v2
@@ -7,12 +7,10 @@
 import testing ;
 import mpi : mpi-test ;
 
-use-project boost : $(BOOST_ROOT) ;
-
 project
     : requirements
       <library>/boost/test//boost_unit_test_framework
-      <library>/boost//mpi
+      <library>/boost/mpi//boost_mpi
       <link>static
       <define>BOOST_ALL_NO_LIB=1
     ;

--- a/test_external/mtl4/Jamfile.v2
+++ b/test_external/mtl4/Jamfile.v2
@@ -7,9 +7,6 @@
 import testing ;
 import boost ;
 
-# boost.use-project ;
-use-project boost : $(BOOST_ROOT) ;
-
 # set your MTL4 directory here
 MTL4_INCLUDE = /home/mario/MTL4/usr/include ;
 

--- a/test_external/nt2/Jamfile.v2
+++ b/test_external/nt2/Jamfile.v2
@@ -22,7 +22,7 @@ local NT2_SIMD_FLAGS = [ os.environ NT2_SIMD_FLAGS ] ;
 
 project
   : requirements
-    <library>/boost/test//boost_test
+    <library>/boost/test//included
     <define>BOOST_ALL_NO_LIB=1
     <include>$(NT2_ROOT_PATH)/include/
     <link>static

--- a/test_external/nt2/Jamfile.v2
+++ b/test_external/nt2/Jamfile.v2
@@ -20,11 +20,9 @@ import os ;
 local NT2_ROOT_PATH = [ os.environ NT2_ROOT_PATH ] ;
 local NT2_SIMD_FLAGS = [ os.environ NT2_SIMD_FLAGS ] ;
 
-use-project boost : $(BOOST_ROOT) ;
-
 project
   : requirements
-    <library>$(BOOST_ROOT)/boost/test/included/unit_test_framework.hpp
+    <library>/boost/test//boost_test
     <define>BOOST_ALL_NO_LIB=1
     <include>$(NT2_ROOT_PATH)/include/
     <link>static

--- a/test_external/vexcl/Jamfile.v2
+++ b/test_external/vexcl/Jamfile.v2
@@ -8,7 +8,6 @@
 
 import testing ;
 
-use-project boost : $(BOOST_ROOT) ;
 VEXCL_INCLUDE = /home/karsten/boost/testing/vexcl ;
 OPENCL_INCLUDE = /usr/local/cuda/include ;
 #OPENCL_INCLUDE = /usr/include ;
@@ -20,7 +19,7 @@ project
       <include>$(VEXCL_INCLUDE)
       <include>$(OPENCL_INCLUDE)
       <cxxflags>-std=c++0x
-      <library>/boost//system/
+      <library>/boost/system//boost_system
     ;
 
 lib OpenCL : : <name>OpenCL <link>shared ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.